### PR TITLE
Fix the refline drawing issue

### DIFF
--- a/src/modules/view/WindowController.cpp
+++ b/src/modules/view/WindowController.cpp
@@ -41,7 +41,7 @@ public:
     
     void onFrameProcess(const Mat& frame, const Mat& debugFrame) {
         // draw measurement lines
-        line(frame, Point(0, counter->refLine.end.y), Point(frame.cols, counter->refLine.end.y), COLOR_ENTRANCE_LINE, 2);
+        line(frame, Point(0, counter->refLine.start.y), Point(frame.cols, counter->refLine.end.y), COLOR_ENTRANCE_LINE, 2);
 
         // draw counters
         putText(frame, to_string(counter->peopleWhoEnteredCount) + " UP", Point(10, 20), FONT_HERSHEY_COMPLEX_SMALL, 0.75, COLOR_ENTRANCE_LINE);


### PR DESCRIPTION
The reference line was drawn in the same position, irrespective of the input reference line position. This was due to the issue of drawing the line in `WindowController.cpp`. The reference points given were the same. 